### PR TITLE
feat: add sign-out resource and UI sign-out flow (Issue #6)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -56,6 +56,16 @@
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
     <version>1.14.3</version>
+    <exclusions>
+      <exclusion>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+      </exclusion>
+      <exclusion>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-nop</artifactId>
+      </exclusion>
+    </exclusions>
     </dependency>
 
     <!--  For decrypting JWT  -->
@@ -73,6 +83,19 @@
     <version>5.80.0</version>
     </dependency>
 
+
+        <!-- Force SLF4J 2.x to align all dependencies and avoid LoggerFactory conflict -->
+        <!-- Align Jackson with Spring Boot 3 (needed by Spring Web) -->
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>2.0.13</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.17.1</version>
+        </dependency>
 
   </dependencies>
 

--- a/backend/src/main/java/com/intsof/samples/entra/controller/AuthController.java
+++ b/backend/src/main/java/com/intsof/samples/entra/controller/AuthController.java
@@ -4,6 +4,8 @@ package com.intsof.samples.entra.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 
 
@@ -15,6 +17,15 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<?> login() {
         // Authentication is handled by the filter. If we reach here, user is authenticated.
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/intsof/samples/entra/filter/AuthenticationFilter.java
+++ b/backend/src/main/java/com/intsof/samples/entra/filter/AuthenticationFilter.java
@@ -37,6 +37,11 @@ public class AuthenticationFilter implements Filter {
         Code below needs to be refactored to use the correct provider / database logic needd moved to the correct provider
         */
         
+        if (path.equals("/logout")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         if (path.equals("/login") && req.getMethod().equalsIgnoreCase("POST")) {
             // Handle login directly in filter
             String email = req.getHeader("X-Email");

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,8 +1,9 @@
 import { Routes } from '@angular/router';
+import { AuthGuard } from './services/auth.guard';
 import { LoginComponent } from './components/login/login.component';
 import { WelcomeComponent } from './components/welcome/welcome.component';
 
 export const routes: Routes = [
   { path: '', component: LoginComponent },
-  { path: 'welcome', component: WelcomeComponent }
+  { path: 'welcome', component: WelcomeComponent, canActivate: [AuthGuard] }
 ];

--- a/frontend/src/app/components/welcome/welcome.component.css
+++ b/frontend/src/app/components/welcome/welcome.component.css
@@ -1,10 +1,24 @@
 .welcome-container {
+  flex-direction: column;
   display: flex;
   justify-content: center;
   align-items: center;
   height: 80vh;
 }
+
+.logout-btn {
+  padding: 0.6rem 2rem;
+  font-size: 1.1rem;
+  transition: all 0.3s ease;
+}
+
+.logout-btn:hover {
+  background-color: #1565c0;
+  transform: translateY(-2px);
+}
+
 .welcome-message {
+  margin-bottom: 1.5rem;
   font-size: 4rem;
   font-weight: bold;
   color: #1976d2;

--- a/frontend/src/app/components/welcome/welcome.component.html
+++ b/frontend/src/app/components/welcome/welcome.component.html
@@ -1,3 +1,4 @@
 <div class="welcome-container">
   <h1 class="welcome-message">Welcome {{ email }}!!! You are authenticated.</h1>
+  <button class="btn btn-primary logout-btn" (click)="signOut()">Sign Out</button>
 </div>

--- a/frontend/src/app/components/welcome/welcome.component.ts
+++ b/frontend/src/app/components/welcome/welcome.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { AuthService } from '../../services/auth.service';
+
 @Component({
   selector: 'app-welcome',
   standalone: true,
@@ -9,8 +11,19 @@ import { Router } from '@angular/router';
 })
 export class WelcomeComponent {
   email: string = '';
-  constructor(private router: Router) {
+  constructor(private router: Router, private authService: AuthService) {
     const nav = this.router.getCurrentNavigation();
     this.email = nav?.extras.state?.['email'] || '';
+  }
+
+  signOut() {
+    this.authService.logout().subscribe({
+      next: () => {
+        this.router.navigate(['']);
+      },
+      error: () => {
+        this.router.navigate(['']);
+      }
+    });
   }
 }

--- a/frontend/src/app/services/auth.guard.ts
+++ b/frontend/src/app/services/auth.guard.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private router: Router) {}
+
+  canActivate(): boolean {
+    const authenticated = sessionStorage.getItem('authenticated') === 'true';
+    if (!authenticated) {
+      this.router.navigate(['']);
+      return false;
+    }
+    return true;
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,7 +1,7 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { catchError } from 'rxjs/operators';
+import { catchError, tap } from 'rxjs/operators';
 import { throwError, Observable } from 'rxjs';
 
 @Injectable({
@@ -21,6 +21,20 @@ export class AuthService {
     // Send empty body, credentials in headers
     return this.http.post(this.loginUrl, {}, { headers })
       .pipe(
+        tap(() => {
+          sessionStorage.setItem('authenticated', 'true');
+          sessionStorage.setItem('email', email);
+        }),
+        catchError(this.handleError)
+      );
+  }
+
+  logout(): Observable<any> {
+    return this.http.post('http://localhost:8080/logout', {}, {})
+      .pipe(
+        tap(() => {
+          sessionStorage.clear();
+        }),
         catchError(this.handleError)
       );
   }


### PR DESCRIPTION
**Description**  
This PR closes #6 by adding a complete “sign out” experience:

**Backend**  
- Introduced `POST /logout` in `AuthController` to invalidate the Java HTTP session.  
- Adjusted `AuthenticationFilter` to allow `/logout` through without requiring credentials.  

**Frontend**  
- Added `logout()` in `AuthService` which calls `/logout` and clears `sessionStorage`.  
- Created an `AuthGuard` to protect the `/welcome` route and redirect unauthenticated users back to login.  
- Updated routing configuration to apply `AuthGuard` on the welcome page.  
- In `WelcomeComponent`:
  - Injected `AuthService` and wired up a “Sign Out” button under the welcome message.
  - Styled the button (centered under the heading, spacing, hover lift and color change) for a polished look.

**How to test**  
1. Log in with `test1@example.com` / `test1`.  
2. You land on the Welcome screen.  
3. Click **Sign Out** – you should be routed back to the login page and prevented from revisiting `/welcome` without logging in again.

**GIF Demo**  
_Attaching a short GIF below to showcase login → welcome → sign-out flow_  
![2025-07-3014-00-10-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/de228bcd-f870-4b56-ae25-38c9d7d4bd83)