### PR TITLE
feat(login): show error message on login failure (#9)

### DIFF
--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -3,6 +3,9 @@
   <div class="row justify-content-center">
     <div class="col-md-4">
       <h2 class="text-center mb-4">Login</h2>
+        <div *ngIf="errorMessage" class="alert alert-danger" role="alert">
+          {{ errorMessage }}
+        </div>
       <form (ngSubmit)="login()">
         <div class="mb-3">
           <label for="email" class="form-label">Email</label>

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -30,7 +30,9 @@ export class LoginComponent {
         }
       },
       error: (err: HttpErrorResponse) => {
-        if (err.status === 0) {
+        if (err.error && err.error.error) {
+          this.errorMessage = err.error.error;
+        } else if (err.status === 0) {
           this.errorMessage = 'Cannot connect to server.';
         } else {
           this.errorMessage = 'An unexpected error occurred.';


### PR DESCRIPTION
Description 
Closes #9

This PR enhances the login screen so that failures surface immediately to the user with specific error messages.

**Frontend Changes**  
- Added a Bootstrap alert in `login.component.html` that displays when `errorMessage` is set, providing visual feedback on login failure.  
- Updated `login.component.ts` to extract and display the exact error message from the backend response (if available), with fallbacks for network issues or unexpected errors.

**Backend Changes**  
- No changes were required in the backend for this feature as it already returns appropriate error messages in the response JSON (e.g., "Invalid credentials"). The frontend now properly handles and displays these messages.

**Preview**  
The feature: logging in with incorrect credentials displays a red alert with the specific reason for failure.
![2025-07-3017-26-37-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/13a1fccf-6a6f-4ab2-8ac2-df7285245d1d)