### PR TITLE
feat: implement Entra login and domain-based application filtering

### DIFF
--- a/backend/src/main/java/com/intsof/samples/entra/config/SsoConfigProperties.java
+++ b/backend/src/main/java/com/intsof/samples/entra/config/SsoConfigProperties.java
@@ -4,6 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Binds all SSO-related settings from application.properties/environment variables so that other
@@ -19,6 +21,7 @@ public class SsoConfigProperties {
 
     private Registration registration = new Registration();
     private Provider provider = new Provider();
+    private Map<String, List<String>> verifiedApps = new HashMap<>();
 
     // ---------------------------------------------------------------------
     // Getters / setters
@@ -46,6 +49,14 @@ public class SsoConfigProperties {
 
     public void setProvider(Provider provider) {
         this.provider = provider;
+    }
+
+    public Map<String, List<String>> getVerifiedApps() {
+        return verifiedApps;
+    }
+
+    public void setVerifiedApps(Map<String, List<String>> verifiedApps) {
+        this.verifiedApps = verifiedApps;
     }
 
     // =====================================================================

--- a/backend/src/main/java/com/intsof/samples/entra/dto/LoginRequest.java
+++ b/backend/src/main/java/com/intsof/samples/entra/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.intsof.samples.entra.dto;
+
+public class LoginRequest {
+    private String username;
+    private String password;
+
+    public LoginRequest() {}
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/backend/src/main/java/com/intsof/samples/entra/dto/TokenResponse.java
+++ b/backend/src/main/java/com/intsof/samples/entra/dto/TokenResponse.java
@@ -9,6 +9,7 @@ public class TokenResponse {
     private long expiresIn;
     private String username;
     private List<String> roles;
+    private List<String> applications;
 
     public TokenResponse() {}
 
@@ -37,4 +38,7 @@ public class TokenResponse {
 
     public List<String> getRoles() { return roles; }
     public void setRoles(List<String> roles) { this.roles = roles; }
+
+    public List<String> getApplications() { return applications; }
+    public void setApplications(List<String> applications) { this.applications = applications; }
 }

--- a/backend/src/main/java/com/intsof/samples/entra/service/VerifiedAppService.java
+++ b/backend/src/main/java/com/intsof/samples/entra/service/VerifiedAppService.java
@@ -1,0 +1,30 @@
+package com.intsof.samples.entra.service;
+
+import org.springframework.stereotype.Service;
+import com.intsof.samples.entra.config.SsoConfigProperties;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Service
+public class VerifiedAppService {
+
+    private final Map<String, List<String>> verifiedApps;
+
+    @Autowired
+    public VerifiedAppService(SsoConfigProperties ssoConfigProperties) {
+        this.verifiedApps = ssoConfigProperties.getVerifiedApps() != null
+                ? ssoConfigProperties.getVerifiedApps()
+                : new HashMap<>();
+    }
+
+    public List<String> getVerifiedApplicationsForDomain(String domain) {
+        if (domain == null) {
+            return Collections.emptyList();
+        }
+        String normalizedDomain = domain.toLowerCase();
+        return verifiedApps.getOrDefault(normalizedDomain, Collections.emptyList());
+    }
+}

--- a/backend/src/test/java/com/intsof/samples/entra/controller/EntraAuthControllerTest.java
+++ b/backend/src/test/java/com/intsof/samples/entra/controller/EntraAuthControllerTest.java
@@ -1,0 +1,82 @@
+package com.intsof.samples.entra.controller;
+
+import com.intsof.samples.entra.dto.LoginRequest;
+import com.intsof.samples.entra.dto.TokenResponse;
+import com.intsof.samples.entra.service.EntraIdService;
+import com.intsof.samples.entra.service.EntraIdService.EntraTokenValidationResult;
+import com.intsof.samples.entra.service.EntraIdService.EntraUserProfile;
+import com.intsof.samples.entra.service.VerifiedAppService;
+import com.intsof.samples.entra.service.JwtService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EntraAuthControllerTest {
+
+    @InjectMocks
+    private EntraAuthController controller;
+
+    @Mock
+    private EntraIdService entraIdService;
+
+    @Mock
+    private VerifiedAppService verifiedAppService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Test
+    void loginWithCredentials_success() {
+        LoginRequest req = new LoginRequest();
+        req.setUsername("user@example.com");
+        req.setPassword("pass");
+
+        EntraUserProfile profile = new EntraUserProfile(
+                "user@example.com", "Name", "Given", "Family", "sub",
+                List.of("USER"), List.of());
+        EntraTokenValidationResult result = new EntraTokenValidationResult(true, "Success", profile);
+        when(entraIdService.authenticateWithCredentials("user@example.com", "pass")).thenReturn(result);
+        when(verifiedAppService.getVerifiedApplicationsForDomain("example.com")).thenReturn(List.of("app1", "app2"));
+        when(jwtService.generateToken(eq("user@example.com"), eq(profile.getRoles()), anyMap())).thenReturn("access-token");
+        when(jwtService.generateRefreshToken("user@example.com")).thenReturn("refresh-token");
+
+        ResponseEntity<?> response = controller.loginWithCredentials(req);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody() instanceof TokenResponse);
+        TokenResponse tokenResponse = (TokenResponse) response.getBody();
+        assertEquals("access-token", tokenResponse.getAccessToken());
+        assertEquals("refresh-token", tokenResponse.getRefreshToken());
+        assertEquals(List.of("app1", "app2"), tokenResponse.getApplications());
+    }
+
+    @Test
+    void loginWithCredentials_failure() {
+        LoginRequest req = new LoginRequest();
+        req.setUsername("user@example.com");
+        req.setPassword("bad");
+
+        EntraTokenValidationResult result = new EntraTokenValidationResult(false, "Invalid credentials", null);
+        when(entraIdService.authenticateWithCredentials("user@example.com", "bad")).thenReturn(result);
+
+        ResponseEntity<?> response = controller.loginWithCredentials(req);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertTrue(response.getBody() instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, String> error = (Map<String, String>) response.getBody();
+        assertEquals("Invalid credentials", error.get("error"));
+    }
+}

--- a/backend/src/test/java/com/intsof/samples/entra/integration/LoginFlowIntegrationTest.java
+++ b/backend/src/test/java/com/intsof/samples/entra/integration/LoginFlowIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.intsof.samples.entra.integration;
+
+import com.intsof.samples.entra.service.EntraIdService;
+import com.intsof.samples.entra.service.EntraIdService.EntraTokenValidationResult;
+import com.intsof.samples.entra.service.EntraIdService.EntraUserProfile;
+import com.intsof.samples.entra.service.JwtService;
+import com.intsof.samples.entra.service.VerifiedAppService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {"spring.sql.init.mode=never"})
+@AutoConfigureMockMvc(addFilters = false)
+class LoginFlowIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EntraIdService entraIdService;
+
+    @MockBean
+    private VerifiedAppService verifiedAppService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    void whenValidCredentials_thenReturnsJwtAndApplications() throws Exception {
+        String username = "user@example.com";
+        String password = "pass";
+        List<String> roles = List.of("USER");
+        EntraUserProfile profile = new EntraUserProfile(
+                username, "Name", "Given", "Family", "sub", roles, List.of());
+        EntraTokenValidationResult validationResult = new EntraTokenValidationResult(true, "Success", profile);
+        when(entraIdService.authenticateWithCredentials(eq(username), eq(password))).thenReturn(validationResult);
+        when(verifiedAppService.getVerifiedApplicationsForDomain("example.com")).thenReturn(List.of("app1", "app2"));
+        when(jwtService.generateToken(eq(username), eq(roles), anyMap())).thenReturn("access-token");
+        when(jwtService.generateRefreshToken(eq(username))).thenReturn("refresh-token");
+
+        String requestBody = "{\"username\":\"" + username + "\",\"password\":\"" + password + "\"}";
+
+        mockMvc.perform(post("/auth/entra/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.accessToken").value("access-token"))
+            .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+            .andExpect(jsonPath("$.applications[0]").value("app1"))
+            .andExpect(jsonPath("$.applications[1]").value("app2"));
+    }
+
+    @Test
+    void whenInvalidCredentials_thenReturnsUnauthorized() throws Exception {
+        String username = "user@example.com";
+        String password = "bad";
+        EntraTokenValidationResult validationResult = new EntraTokenValidationResult(false, "Invalid credentials", null);
+        when(entraIdService.authenticateWithCredentials(eq(username), eq(password))).thenReturn(validationResult);
+
+        String requestBody = "{\"username\":\"" + username + "\",\"password\":\"" + password + "\"}";
+
+        mockMvc.perform(post("/auth/entra/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error").value("Invalid credentials"));
+    }
+}

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -57,7 +57,8 @@ export class LoginComponent implements OnInit {
           this.errorMessage = response.error;
         } else if (this.authService.isAuthenticated()) {
           this.errorMessage = '';
-          this.router.navigate(['/welcome'], { state: { email: this.email } });
+          const applications = (response as any).applications || [];
+          this.router.navigate(['/welcome'], { state: { email: this.email, applications } });
         } else {
           this.errorMessage = 'Login failed.';
         }

--- a/frontend/src/app/components/welcome/welcome.component.html
+++ b/frontend/src/app/components/welcome/welcome.component.html
@@ -1,4 +1,10 @@
 <div class="welcome-container">
   <h1 class="welcome-message">Welcome {{ email }}!!! You are authenticated.</h1>
   <button class="btn btn-primary logout-btn" (click)="signOut()">Sign Out</button>
+  <div *ngIf="applications.length > 0" class="mt-3">
+    <h3>Your Verified Applications:</h3>
+    <ul class="list-group">
+      <li class="list-group-item" *ngFor="let app of applications">{{ app }}</li>
+    </ul>
+  </div>
 </div>

--- a/frontend/src/app/components/welcome/welcome.component.ts
+++ b/frontend/src/app/components/welcome/welcome.component.ts
@@ -11,9 +11,11 @@ import { AuthService } from '../../services/auth.service';
 })
 export class WelcomeComponent {
   email: string = '';
+  applications: string[] = [];
   constructor(private router: Router, private authService: AuthService) {
     const nav = this.router.getCurrentNavigation();
     this.email = nav?.extras.state?.['email'] || '';
+    this.applications = nav?.extras.state?.['applications'] || [];
   }
 
   signOut() {


### PR DESCRIPTION
Closes #26

Summary:
This PR replaces our local JWT login with a delegate to Microsoft Entra, extracts the user’s email domain from the returned token, and then filters the list of applications to only those pre-verified for that domain. Both backend and frontend have been updated, and unit/integration tests added.

Backend changes:
- EntraIdService: added `authenticateWithCredentials` which calls the Entra token endpoint via ROPC, and reused `validateToken`.
- SsoConfigProperties: added `verifiedApps` map for domain→apps.
- VerifiedAppService: new service to look up verified applications by domain.
- EntraAuthController:
  - Added `POST /auth/entra/login` for credential login.
  - Extended OAuth callback and token-validation endpoints to include `applications` in JWT claims and response DTO.
- DTOs: `LoginRequest`, `TokenResponse` updated to carry `applications`.
- Tests: unit tests for controller; integration tests for end-to-end login flow including app filtering.

Frontend changes:
- LoginComponent:
  - After successful password login, reads `applications` from the response.
  - Passes both `email` and `applications` into router state.
- WelcomeComponent:
  - Reads `applications` from navigation state.
  - Renders a list of “Your Verified Applications”.
- Templates and styling updated accordingly.

How to test:
1. Run backend tests:  
   ```bash
   cd backend
   mvn clean test
   ```
2. Start the backend, then in `frontend`:  
   ```bash
   npm install
   npm start
   ```
3. On the login screen, enter a user whose email domain is in `application.properties → sso.verifiedApps`.  
4. After login, you should be redirected to the welcome page and see only the applications configured for your domain.